### PR TITLE
Content for Linux, Free Stuff and Set Up Environment home page 

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,11 +1,9 @@
-tlsv
-Voil
-Woooah
 andrzej
 atlassian
 clion
 cmake
 courseworks
+digitalocean
 ghc
 ghci
 ghcup
@@ -16,9 +14,14 @@ jetbrains
 learngitbranching
 learnyouahaskell
 LOL
+metapackage
 MPEB
 pycharm
 pythonorg
 scm
+tlsv
 ucl
+virtualenv
+Voil
+Woooah
 xkcd

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -109,7 +109,6 @@ jobs:
         spell_check_this: check-spelling/spell-check-this@prerelease
         task: ${{ needs.spelling.outputs.followup }}
         
-
   comment-pr:
     name: Report (PR)
     # If you workflow isn't running on pull_request*, you can remove this job

--- a/docs/set-up-environment/free-stuff.md
+++ b/docs/set-up-environment/free-stuff.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 2
 sidebar_label: 🎁 Free Stuff
 ---
 

--- a/docs/set-up-environment/index.mdx
+++ b/docs/set-up-environment/index.mdx
@@ -29,9 +29,11 @@ Thank you!
 
 :::
 
+## Next Steps...
+
+<DocCardList />
+
 ## Credits
 
 We proudly reuse and improve materials created throughout the Programming Tutoring scheme
 by other Senior Programming Tutors, including the contributors of [this GitHub repo](https://github.com/greenfrogs/ucl_cs_setup_your_environment/tree/master).
-
-<DocCardList />

--- a/docs/set-up-environment/linux.md
+++ b/docs/set-up-environment/linux.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 sidebar_label: 🐧 Linux
 ---
 

--- a/docs/set-up-environment/macos/_category_.json
+++ b/docs/set-up-environment/macos/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "🍎 MacOS",
-  "position": 3,
+  "position": 4,
   "link": {
     "type": "doc",
     "id": "set-up-environment/macos/index"

--- a/docs/set-up-environment/macos/index.mdx
+++ b/docs/set-up-environment/macos/index.mdx
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 import DocCardList from "@theme/DocCardList";
 
-# 🍎 Mac Getting Started
+# 🍎 MacOS Getting Started
 
 You have it slightly easier than the 🪟 Windows users, but there's still some work to do! Luckily for you people,
 a lot of the work is done for you and doesn't require typing much.
@@ -128,18 +128,18 @@ brew install git
 You can then configure your username and email:
 
 ```bash
-git config --global user.name "Username"
-git config --global user.email "Email-Use-Github-Anonymous"
+git config --global user.name "YourUsername"
+git config --global user.email "YourEmail"
 ```
 
-To find your github email address you can go here: https://github.com/settings/emails.
+To find your GitHub email address you can go here: https://github.com/settings/emails.
 
 \*_when used properly, LOL_
 
 :::tip
 
 You will be using `git` and GitHub in several modules and courseworks.
-There are multiple ways of interactig with GitHub. You can use:
+There are multiple ways of interacting with GitHub. You can use:
 
 - [GitHub Desktop](https://desktop.github.com/),
 - Git/GitHub extension to your IDE,
@@ -153,5 +153,7 @@ We **recommend** trying the command line interface. There is a range of useful t
 
 To make this as smooth as possible, you may want to [read how to use Secure Shell (SSH)](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/connecting-to-github-with-ssh) to connect to GitHub!
 :::
+
+## Next Steps
 
 <DocCardList />

--- a/docs/set-up-environment/windows/_category_.json
+++ b/docs/set-up-environment/windows/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "🪟 Windows",
-  "position": 2,
+  "position": 3,
   "link": {
     "type": "doc",
     "id": "set-up-environment/windows/index"


### PR DESCRIPTION
This PR introduced the following changes:
- Added Linux page content #12 
- Added Free Stuff page content
- Added Set Up Environment page content
- Fixed some typos on the MacOS page and change the ordering of Set Up Environment pages
- Modified behaviour of the spell checking workflow 

Spell-check: This PR marks some words as correctly spelled. 

Closes: #12, #16 
Modifies: #4 

Linux getting started:
![image](https://github.com/TheRootOf3/ucl-cs-hub/assets/45316794/39b9bb35-62f5-475f-8918-44b6ac197e0d)

Free Stuff:
![image](https://github.com/TheRootOf3/ucl-cs-hub/assets/45316794/d9193b42-7076-45c1-b9c5-e080c9fef23d)

Set Up Your Environment homepage:
![image](https://github.com/TheRootOf3/ucl-cs-hub/assets/45316794/ee1bf4f6-ed6f-4137-a080-4b47f7236547)
