### PR TITLE
Added cs labs availability and the announcement bar!

### DIFF
--- a/docs/labs-availability/MPEB105.md
+++ b/docs/labs-availability/MPEB105.md
@@ -5,24 +5,27 @@ description: ""
 ---
 
 # MPEB 1.05
+
 Come grab a seat to study, chat, or relax with a cup of joe! ☕️
 
 ## Timetable
-| Time/Day        | Monday | Tuesday | Wednesday | Thursday | Friday |
-|-----------------|:------:|:-------:|:---------:|:--------:|:------:|
-| **8AM - 9AM**   |   -    |    -    |     -     |    -     |   -    |
-| **9AM - 10AM**  |   -    |    -    |     -     |    -     |   -    |
-| **10AM - 11AM** |   -    |    -    |     -     |    -     |   -    |
-| **11AM - 12PM** |   -    |    -    |     -     |    -     |   -    |
-| **12PM - 1PM**  |   -    |    -    |     -     |    -     |   -    |
-| **1PM - 2PM**   |   -    |    -    |     -     |    -     |   -    |
-| **2PM - 3PM**   |   -    |    -    |     -     |    -     |   -    |
-| **3PM - 4PM**   |   -    |    -    |     -     |    -     |   -    |
-| **4PM - 5PM**   |   -    |    -    |     -     |    -     |   -    |
-| **5PM - 6PM**   |   -    |    -    |     -     |    -     |   -    |
-| **6PM - 7PM**   |   -    |    -    |     -     |    -     |   -    |
+
+| Time/Day        |   Monday    |   Tuesday   |  Wednesday  |  Thursday   |   Friday    |
+| --------------- | :---------: | :---------: | :---------: | :---------: | :---------: |
+| **8AM - 9AM**   |     ✅      |     ✅      |     ✅      |     ✅      |     ✅      |
+| **9AM - 10AM**  |     ✅      | COMP0016 ❌ |     ✅      |     ✅      |     ✅      |
+| **10AM - 11AM** |     ✅      | COMP0016 ❌ |     ✅      |     ✅      |     ✅      |
+| **11AM - 12PM** | COMP0002 ❌ | COMP0002 ❌ | COMP0137 ❌ |     ✅      | COMP0173 ❌ |
+| **12PM - 1PM**  | COMP0002 ❌ | COMP0002 ❌ | COMP0137 ❌ | COMP0016 ❌ |     ✅      |
+| **1PM - 2PM**   |     ✅      | COMP0002 ❌ | COMP0137 ❌ | COMP0016 ❌ | COMP0015 ❌ |
+| **2PM - 3PM**   |     ✅      | COMP0002 ❌ |     ✅      |     ✅      | COMP0015 ❌ |
+| **3PM - 4PM**   | COMP0015 ❌ | COMP0016 ❌ |     ✅      | COMP0015 ❌ | COMP0015 ❌ |
+| **4PM - 5PM**   | COMP0015 ❌ | COMP0016 ❌ |     ✅      | COMP0015 ❌ | COMP0015 ❌ |
+| **5PM - 6PM**   |     ✅      |     ✅      |     ✅      |     ✅      |     ✅      |
+| **6PM - 7PM**   |     ✅      |     ✅      |     ✅      |     ✅      |     ✅      |
 
 ## Directions
+
 Malet Place Engineering Building, 1st floor, Room 1.05.
 
 <p align="center">

--- a/docs/labs-availability/MPEB121.md
+++ b/docs/labs-availability/MPEB121.md
@@ -5,24 +5,27 @@ description: ""
 ---
 
 # MPEB 1.21
+
 Come grab a seat to study, chat, or relax with a cup of joe! ☕️
 
 ## Timetable
-| Time/Day        | Monday | Tuesday | Wednesday | Thursday | Friday |
-|-----------------|:------:|:-------:|:---------:|:--------:|:------:|
-| **8AM - 9AM**   |   -    |    -    |     -     |    -     |   -    |
-| **9AM - 10AM**  |   -    |    -    |     -     |    -     |   -    |
-| **10AM - 11AM** |   -    |    -    |     -     |    -     |   -    |
-| **11AM - 12PM** |   -    |    -    |     -     |    -     |   -    |
-| **12PM - 1PM**  |   -    |    -    |     -     |    -     |   -    |
-| **1PM - 2PM**   |   -    |    -    |     -     |    -     |   -    |
-| **2PM - 3PM**   |   -    |    -    |     -     |    -     |   -    |
-| **3PM - 4PM**   |   -    |    -    |     -     |    -     |   -    |
-| **4PM - 5PM**   |   -    |    -    |     -     |    -     |   -    |
-| **5PM - 6PM**   |   -    |    -    |     -     |    -     |   -    |
-| **6PM - 7PM**   |   -    |    -    |     -     |    -     |   -    |
+
+| Time/Day        |   Monday    |   Tuesday   |  Wednesday  |  Thursday   |   Friday    |
+| --------------- | :---------: | :---------: | :---------: | :---------: | :---------: |
+| **8AM - 9AM**   |     ✅      |     ✅      |     ✅      |     ✅      |     ✅      |
+| **9AM - 10AM**  |     ✅      | COMP0016 ❌ |     ✅      |     ✅      |     ✅      |
+| **10AM - 11AM** |     ✅      | COMP0016 ❌ |     ✅      |     ✅      |     ✅      |
+| **11AM - 12PM** | COMP0002 ❌ | COMP0002 ❌ | COMP0137 ❌ |     ✅      | COMP0173 ❌ |
+| **12PM - 1PM**  | COMP0002 ❌ | COMP0002 ❌ | COMP0137 ❌ | COMP0016 ❌ |     ✅      |
+| **1PM - 2PM**   |     ✅      | COMP0002 ❌ | COMP0137 ❌ | COMP0016 ❌ | COMP0015 ❌ |
+| **2PM - 3PM**   |     ✅      | COMP0002 ❌ |     ✅      |     ✅      | COMP0015 ❌ |
+| **3PM - 4PM**   | COMP0015 ❌ | COMP0016 ❌ |     ✅      | COMP0015 ❌ | COMP0015 ❌ |
+| **4PM - 5PM**   | COMP0015 ❌ | COMP0016 ❌ |     ✅      | COMP0015 ❌ | COMP0015 ❌ |
+| **5PM - 6PM**   |     ✅      |     ✅      |     ✅      |     ✅      |     ✅      |
+| **6PM - 7PM**   |     ✅      |     ✅      |     ✅      |     ✅      |     ✅      |
 
 ## Directions
+
 Malet Place Engineering Building, 1st floor, Room 1.21.
 
 <p align="center">

--- a/docs/labs-availability/MPEB406.md
+++ b/docs/labs-availability/MPEB406.md
@@ -5,24 +5,27 @@ description: ""
 ---
 
 # MPEB 4.06
+
 Come grab a seat to study, chat, or relax with a cup of joe! ☕️
 
 ## Timetable
-| Time/Day        | Monday | Tuesday | Wednesday | Thursday | Friday |
-|-----------------|:------:|:-------:|:---------:|:--------:|:------:|
-| **8AM - 9AM**   |   -    |    -    |     -     |    -     |   -    |
-| **9AM - 10AM**  |   -    |    -    |     -     |    -     |   -    |
-| **10AM - 11AM** |   -    |    -    |     -     |    -     |   -    |
-| **11AM - 12PM** |   -    |    -    |     -     |    -     |   -    |
-| **12PM - 1PM**  |   -    |    -    |     -     |    -     |   -    |
-| **1PM - 2PM**   |   -    |    -    |     -     |    -     |   -    |
-| **2PM - 3PM**   |   -    |    -    |     -     |    -     |   -    |
-| **3PM - 4PM**   |   -    |    -    |     -     |    -     |   -    |
-| **4PM - 5PM**   |   -    |    -    |     -     |    -     |   -    |
-| **5PM - 6PM**   |   -    |    -    |     -     |    -     |   -    |
-| **6PM - 7PM**   |   -    |    -    |     -     |    -     |   -    |
+
+| Time/Day        |   Monday    |   Tuesday   | Wednesday |  Thursday   | Friday |
+| --------------- | :---------: | :---------: | :-------: | :---------: | :----: |
+| **8AM - 9AM**   |     ✅      |     ✅      |    ✅     |     ✅      |   ✅   |
+| **9AM - 10AM**  |     ✅      | COMP0016 ❌ |    ✅     |     ✅      |   ✅   |
+| **10AM - 11AM** |     ✅      | COMP0016 ❌ |    ✅     |     ✅      |   ✅   |
+| **11AM - 12PM** | COMP0002 ❌ | COMP0002 ❌ |    ✅     |     ✅      |   ✅   |
+| **12PM - 1PM**  | COMP0002 ❌ | COMP0002 ❌ |    ✅     | COMP0016 ❌ |   ✅   |
+| **1PM - 2PM**   |     ✅      | COMP0002 ❌ |    ✅     | COMP0016 ❌ |   ✅   |
+| **2PM - 3PM**   |     ✅      | COMP0002 ❌ |    ✅     |     ✅      |   ✅   |
+| **3PM - 4PM**   |     ✅      | COMP0016 ❌ |    ✅     |     ✅      |   ✅   |
+| **4PM - 5PM**   |     ✅      | COMP0016 ❌ |    ✅     |     ✅      |   ✅   |
+| **5PM - 6PM**   |     ✅      |     ✅      |    ✅     |     ✅      |   ✅   |
+| **6PM - 7PM**   |     ✅      |     ✅      |    ✅     |     ✅      |   ✅   |
 
 ## Directions
+
 Malet Place Engineering Building, 4th floor, Room 4.06 (a.k.a Apps Lab).
 
 <p align="center">

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,7 +37,7 @@ const config = {
 
   presets: [
     [
-      "classic",
+      "@docusaurus/preset-classic",
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
@@ -62,6 +62,11 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      announcementBar: {
+        id: "announcementBar",
+        content:
+          'CS labs timetables are now available. 🎉 <a href="/docs/labs-availability">Have a look</a>! 👀',
+      },
       // Replace with your project's social card
       // image: "",
       navbar: {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -15,10 +15,11 @@
   --ifm-color-primary-lightest: #3cad6e;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --site-primary-hue-saturation: 147 68%;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
-[data-theme='dark'] {
+[data-theme="dark"] {
   --ifm-color-primary: #25c2a0;
   --ifm-color-primary-dark: #21af90;
   --ifm-color-primary-darker: #1fa588;
@@ -27,4 +28,21 @@
   --ifm-color-primary-lighter: #32d8b4;
   --ifm-color-primary-lightest: #4fddbf;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+}
+
+div[class^="announcementBar_"] {
+  --site-announcement-bar-stripe-color1: hsl(
+    var(--site-primary-hue-saturation) 85%
+  );
+  --site-announcement-bar-stripe-color2: hsl(
+    var(--site-primary-hue-saturation) 95%
+  );
+  background: repeating-linear-gradient(
+    35deg,
+    var(--site-announcement-bar-stripe-color1),
+    var(--site-announcement-bar-stripe-color1) 20px,
+    var(--site-announcement-bar-stripe-color2) 10px,
+    var(--site-announcement-bar-stripe-color2) 40px
+  );
+  font-weight: bold;
 }


### PR DESCRIPTION
This PR introduces the following:
- Added CS Labs availability for MPEB105, MPEB121 and MPEB406.
- Added the announcement bar.

Closes: #24 

Announcement bar:
<img width="1058" alt="image" src="https://github.com/uclcshub/uclcshub.github.io/assets/45316794/2e3f0d16-233d-4cfa-a5dd-ec8466ea061b">

Labs availability timetable for MPEB105:
<img width="1510" alt="image" src="https://github.com/uclcshub/uclcshub.github.io/assets/45316794/ee4282b2-90b7-4d5b-926b-01c404106e87">

