### PR TITLE
:memo: Add instructions to fix cygwin symlink bug on Windows

### DIFF
--- a/docs/set-up-environment/windows/c.mdx
+++ b/docs/set-up-environment/windows/c.mdx
@@ -27,6 +27,24 @@ When installing Cygwin you will need to select
 
 ![Cygwin!](/img//windows-cygwin.png)
 
+<details>
+<summary> Let's test your installation!</summary>
+
+Type `gcc` in your shell. You should receive an `error: no input files` message.
+
+If _not_, then follow the below instructions:
+
+1. Go to the `cygwin` folder in your Files application.
+2. Copy the complete path to the `cygwin/bin` directory.
+3. Right-click "This PC" on the left sidebar.
+4. Select Properties > Advanced > Environment Variables.
+5. Navigate towards the PATH variable in System variables, click "Edit".
+6. Click "New", and paste the copied `cygwin/bin` directory path.
+
+Restart your shell or restart your computer for the changes to take effect.
+
+</details>
+
 ## Configure your IDE
 
 :::tip


### PR DESCRIPTION
Cygwin installation does not automatically add `cygwin/path`; users sometimes need to do it manually. This pull request adds the instructions to add the binary folder manually.

![Screenshot 2023-10-12 at 13 15 43](https://github.com/uclcshub/uclcshub.github.io/assets/72133888/aaa75029-6e1a-49d7-a180-c5170cdc56f0)
